### PR TITLE
page/view role enforcement, prompt robustness, and queue UI fixes

### DIFF
--- a/agent-skills/pagegen.js
+++ b/agent-skills/pagegen.js
@@ -52,20 +52,27 @@ class GeneratePageSkill {
   }
   get userActions() {
     return {
-      async build_copilot_page_gen({ user, name, title, description, html }) {
+      async build_copilot_page_gen({
+        user,
+        name,
+        title,
+        description,
+        html,
+        min_role = 100,
+      }) {
         const file = await File.from_contents(
           `${name}.html`,
           "text/html",
           html,
           user?.id,
-          100,
+          min_role
         );
 
         await Page.create({
           name,
           title,
           description,
-          min_role: 100,
+          min_role,
           layout: { html_file: file.path_to_serve },
         });
         setTimeout(() => getState().refresh_pages(), 200);
@@ -114,7 +121,7 @@ class GeneratePageSkill {
 
  <script src="/static_assets/js/saltcorn-common.js"></script>
  <script src="/static_assets/js/saltcorn.js">
-`,
+`
         );
         const html = str.includes("```html")
           ? str.split("```html")[1].split("```")[0]
@@ -126,6 +133,7 @@ class GeneratePageSkill {
             name: tool_call.input.name,
             title: tool_call.input.title,
             description: tool_call.input.description,
+            min_role: tool_call.input.min_role ?? 100,
             html,
           });
           return {
@@ -148,7 +156,7 @@ class GeneratePageSkill {
           add_user_action: {
             name: "build_copilot_page_gen",
             type: "button",
-            label: "Save page "+tool_call.input.name,
+            label: "Save page " + tool_call.input.name,
             input: { html },
           },
         };
@@ -163,7 +171,7 @@ class GeneratePageSkill {
           response.includes("Unable to provide HTML for this page")
         )
           return response;
-           if (
+        if (
           typeof response === "string" &&
           response.includes("The HTML code for the ")
         )
@@ -193,6 +201,12 @@ class GeneratePageSkill {
               description:
                 "A longer description that is not visible but appears in the page header and is indexed by search engines",
               type: "string",
+            },
+            min_role: {
+              description:
+                "Minimum role required to access this page. Use 1 for admin-only, 40 for staff and above, 80 for logged-in users and above, 100 for public. Set this based on the intended audience described in the task.",
+              type: "integer",
+              enum: [1, 40, 80, 100],
             },
             page_type: {
               description:

--- a/agent-skills/registry-editor.js
+++ b/agent-skills/registry-editor.js
@@ -6,6 +6,7 @@ const Field = require("@saltcorn/data/models/field");
 const User = require("@saltcorn/data/models/user");
 const Plugin = require("@saltcorn/data/models/plugin");
 const Role = require("@saltcorn/data/models/role");
+const File = require("@saltcorn/data/models/file");
 const WorkflowStep = require("@saltcorn/data/models/workflow_step");
 const { getState } = require("@saltcorn/data/db/state");
 
@@ -167,6 +168,7 @@ with both the entity type and name, and the new JSON definition as a string as a
                   "trigger",
                   "plugin",
                   "system-configuration-value",
+                  "file",
                   "type",
                 ],
               },
@@ -316,6 +318,11 @@ with both the entity type and name, and the new JSON definition as a string as a
                 return `The value of "${input.entity_name}" is: ${JSON.stringify(v)}\n\nDescription: ${cfgMeta.description}`;
               }
               return v;
+            }
+            case "file": {
+              const file = await File.findOne({ filename: input.entity_name });
+              if (!file) return `file not found`;
+              return { filename: file.filename, min_role_read: file.min_role_read };
             }
             case "plugin": {
               const plugin = await Plugin.findOne({ name: input.entity_name });
@@ -473,6 +480,7 @@ with both the entity type and name, and the new JSON definition as a string as a
                   "system-configuration-value",
                   "module-configuration",
                   "role",
+                  "file",
                 ],
               },
               entity_name: {
@@ -896,6 +904,13 @@ with both the entity type and name, and the new JSON definition as a string as a
                 if (result?.error) return result.error;
                 await getState().refresh_roles();
                 return "Role created";
+              }
+
+              case "file": {
+                const file = await File.findOne({ filename: input.entity_name });
+                if (!file) return `file not found: ${input.entity_name}`;
+                await file.set_role(entityValue.min_role_read);
+                return "Done";
               }
             }
             return "Done";

--- a/agent-skills/viewgen.js
+++ b/agent-skills/viewgen.js
@@ -437,12 +437,15 @@ class GenerateViewSkill {
             for (const field of form.fields) {
               if (prefilledFields.has(field.name)) continue;
               //TODO showIf
+              const isShowif = field.name.endsWith("_showif");
               properties[field.name] = {
                 description:
                   field.copilot_description ||
-                  `${field.label}.${
-                    field.sublabel ? ` ${field.sublabel}` : ""
-                  }`,
+                  (isShowif
+                    ? `${field.label}. The correct default is an empty string — leave it blank to always show this element. Only provide a JavaScript expression if the task description explicitly states that this element should be conditionally hidden based on a URL state variable or the current user. Never invent field names or copy examples.`
+                    : `${field.label}.${
+                        field.sublabel ? ` ${field.sublabel}` : ""
+                      }`),
                 ...fieldProperties(field),
               };
               if (!properties[field.name].type) {

--- a/app-constructor/run_task.js
+++ b/app-constructor/run_task.js
@@ -43,6 +43,7 @@ const runTask = async (md_id, req) => {
         { skill_type: "Generate trigger", yoloMode: true },
         { skill_type: "Generate View", yoloMode: true },
         { skill_type: "Install Plugin", yoloMode: true },
+        { skill_type: "Registry editor", yoloMode: true },
       ],
     },
   });
@@ -60,7 +61,15 @@ Important: Some fields are non-stored (virtual) calculated fields — they have 
 
 Important: The "users" table is built-in. Passwords are platform-managed — never add a password field to a view. Signup uses the built-in page at /auth/signup, login at /auth/login. Do NOT create triggers for registration or email verification — the platform handles this natively.
 
-Important: To set a page as the home page for a role, use the registry editor to set the system configuration value "home_page_by_role". This is a JSON object mapping role IDs to page names. Role IDs: public=100, user=80, staff=40, admin=1. Example: to set "landing" as the home page for public visitors, set home_page_by_role to {"100": "landing"}. Read the current value first so you can merge with existing entries rather than overwriting them.
+Important: On landing pages, place Log in / Create account buttons in no more than two locations (e.g. navbar and one hero call-to-action). Do not repeat them in a third "Get started" section or anywhere else. For links that take an already-authenticated user to their dashboard, use href="/" — not /auth/login.
+
+Important: Do not name any page or view "Admin dashboard" — that name is reserved by the Saltcorn platform. For pages intended for role 1 (admin), use a name like "App admin dashboard" or prefix it with the application name (e.g. "Law Firm admin dashboard").
+
+Important: When a page is rendered via an HTML file rather than a standard Saltcorn layout, the file itself has its own access role (min_role_read) separate from the page's min_role. After creating or updating such a page, use set_entity with entity_type "file" to set min_role_read on the HTML file to the same role as the page. Use get_entity with entity_type "file" and the filename to read the current value first.
+
+Important: Two-factor authentication (2FA/TOTP) is fully built into the platform. To configure it, call set_entity directly with entity_type "system-configuration-value" and entity_name "twofa_policy_by_role". The entity_definition must be the plain JSON object itself — for example: {"1": "Mandatory", "100": "Disabled"}. Do NOT wrap it in {"type": "json", "value": ...} or any other envelope. Read the current value first with get_entity and merge rather than overwrite. Do NOT create a workflow or trigger to do this.
+
+Important: To set a page as the home page for a role, call set_entity directly with entity_type "system-configuration-value" and entity_name "home_page_by_role". The value is a JSON object mapping role IDs to page names — Role IDs: public=100, user=80, staff=40, admin=1. The entity_definition must be the plain JSON object itself — for example: {"100": "landing", "80": "client_dashboard"}. Do NOT wrap it in {"type": "json", "value": ...} or any other envelope. Read the current value first with get_entity so you can merge rather than overwrite. Do NOT create a workflow or trigger to do this — use set_entity directly.
 
 Important: If the task description mentions adding a viewlink, linking rows to another view, or a button that opens another view from a list — that viewlink column MUST be present in the finished view. Do not skip it. Viewlinks require calling get_relation_paths first to obtain the relation string before generating the layout.
 
@@ -69,40 +78,44 @@ ${md.body.description}`;
   const safeReq = req?.__ ? req : { ...req, __: (s) => s, user: req?.user };
 
   await md.update({ body: { ...md.body, status: "Running" } });
-  const actionres = await agent_action.runWithoutRow({
-    row: { prompt },
-    req: safeReq,
-    user: safeReq.user,
-  });
-  const run_id = actionres.json.run_id;
-  const run = await WorkflowRun.findOne({ id: run_id });
-  await agent_action.runWithoutRow({
-    row: {
-      prompt:
-        "Write a description of what you did, for the purposes of a progress report. Write 1-4 sentences. Do not use any tools or write any code",
-    },
-    req: safeReq,
-    run,
-    user: safeReq.user,
-  });
-  const lastInteraction =
-    run.context.interactions[run.context.interactions.length - 1];
-  const lastText =
-    typeof lastInteraction.content === "string"
-      ? lastInteraction.content
-      : lastInteraction.content.text
-      ? lastInteraction.content.text
-      : Array.isArray(lastInteraction.content)
-      ? lastInteraction.content[0].text
-      : lastInteraction.content;
-  await MetaData.create({
-    type: "CopilotConstructMgr",
-    name: "progress",
-    body: { text: lastText, run_id, task_id: md.id },
-    user_id: req?.user?.id,
-  });
-
-  await md.update({ body: { ...md.body, status: "Done", run_id } });
+  try {
+    const actionres = await agent_action.runWithoutRow({
+      row: { prompt },
+      req: safeReq,
+      user: safeReq.user,
+    });
+    const run_id = actionres.json.run_id;
+    const run = await WorkflowRun.findOne({ id: run_id });
+    await agent_action.runWithoutRow({
+      row: {
+        prompt:
+          "Write a description of what you did, for the purposes of a progress report. Write 1-4 sentences. Do not use any tools or write any code",
+      },
+      req: safeReq,
+      run,
+      user: safeReq.user,
+    });
+    const lastInteraction =
+      run.context.interactions[run.context.interactions.length - 1];
+    const lastText =
+      typeof lastInteraction.content === "string"
+        ? lastInteraction.content
+        : lastInteraction.content.text
+        ? lastInteraction.content.text
+        : Array.isArray(lastInteraction.content)
+        ? lastInteraction.content[0].text
+        : lastInteraction.content;
+    await MetaData.create({
+      type: "CopilotConstructMgr",
+      name: "progress",
+      body: { text: lastText, run_id, task_id: md.id },
+      user_id: req?.user?.id,
+    });
+    await md.update({ body: { ...md.body, status: "Done", run_id } });
+  } catch (e) {
+    await md.update({ body: { ...md.body, status: "To do" } });
+    throw e;
+  }
 };
 
 /**

--- a/app-constructor/run_task.js
+++ b/app-constructor/run_task.js
@@ -95,8 +95,11 @@ ${md.body.description}`;
       run,
       user: safeReq.user,
     });
+    const updatedRun = await WorkflowRun.findOne({ id: run_id });
     const lastInteraction =
-      run.context.interactions[run.context.interactions.length - 1];
+      updatedRun.context.interactions[
+        updatedRun.context.interactions.length - 1
+      ];
     const lastText =
       typeof lastInteraction.content === "string"
         ? lastInteraction.content
@@ -143,9 +146,12 @@ const runNextTask = async (once = false) => {
   );
   const done = tasks.filter((t) => t.body.status === "Done");
   const done_names = new Set(done.map((t) => t.body.name));
+  const all_task_names = new Set(tasks.map((t) => t.body.name).filter(Boolean));
 
   const startable = todos.filter((t) =>
-    t.body.depends_on.every((nm) => done_names.has(nm))
+    (t.body.depends_on || []).every(
+      (nm) => done_names.has(nm) || !all_task_names.has(nm)
+    )
   );
 
   if (startable[0]) {

--- a/app-constructor/run_task.js
+++ b/app-constructor/run_task.js
@@ -65,13 +65,15 @@ Important: On landing pages, place Log in / Create account buttons in no more th
 
 Important: Do not name any page or view "Admin dashboard" — that name is reserved by the Saltcorn platform. For pages intended for role 1 (admin), use a name like "App admin dashboard" or prefix it with the application name (e.g. "Law Firm admin dashboard").
 
-Important: When a page is rendered via an HTML file rather than a standard Saltcorn layout, the file itself has its own access role (min_role_read) separate from the page's min_role. After creating or updating such a page, use set_entity with entity_type "file" to set min_role_read on the HTML file to the same role as the page. Use get_entity with entity_type "file" and the filename to read the current value first.
+Important: When creating a page or view, always set min_role based on the intended audience: 1 for admin-only, 40 for staff and above, 80 for logged-in users and above, 100 for public. Never default to public (100) unless the page or view is explicitly intended for unauthenticated users (e.g. a landing page). A dashboard or view for clients/users is role 80, a staff page or view is role 40, an admin page or view is role 1.
 
 Important: Two-factor authentication (2FA/TOTP) is fully built into the platform. To configure it, call set_entity directly with entity_type "system-configuration-value" and entity_name "twofa_policy_by_role". The entity_definition must be the plain JSON object itself — for example: {"1": "Mandatory", "100": "Disabled"}. Do NOT wrap it in {"type": "json", "value": ...} or any other envelope. Read the current value first with get_entity and merge rather than overwrite. Do NOT create a workflow or trigger to do this.
 
 Important: To set a page as the home page for a role, call set_entity directly with entity_type "system-configuration-value" and entity_name "home_page_by_role". The value is a JSON object mapping role IDs to page names — Role IDs: public=100, user=80, staff=40, admin=1. The entity_definition must be the plain JSON object itself — for example: {"100": "landing", "80": "client_dashboard"}. Do NOT wrap it in {"type": "json", "value": ...} or any other envelope. Read the current value first with get_entity so you can merge rather than overwrite. Do NOT create a workflow or trigger to do this — use set_entity directly.
 
 Important: If the task description mentions adding a viewlink, linking rows to another view, or a button that opens another view from a list — that viewlink column MUST be present in the finished view. Do not skip it. Viewlinks require calling get_relation_paths first to obtain the relation string before generating the layout.
+
+Important: Before creating or updating any view or page that embeds, links to, or opens another view (including viewlinks, action buttons, and ajax_modal calls), call list_entities (entity_type "view") to get all existing view names. Only reference views that appear in that list — never invent a name or assume a view exists. If a view is not in the list, omit the reference entirely. Do the same for pages: call list_entities (entity_type "page") before linking to any page by name.
 
 Your task now is:
 ${md.body.description}`;
@@ -161,6 +163,13 @@ const runNextTask = async (once = false) => {
       : null;
     await runTask(startable[0].id, { user: taskUser, __: (s) => s });
     if (!once) await runNextTask();
+  } else if (!once) {
+    const settings = await MetaData.findOne({
+      type: "CopilotConstructMgr",
+      name: "settings",
+    });
+    if (settings?.body?.running)
+      await settings.update({ body: { ...settings.body, running: false } });
   }
 };
 

--- a/app-constructor/schema.js
+++ b/app-constructor/schema.js
@@ -61,22 +61,69 @@ const showSchema = async (req) => {
       .filter(Boolean);
     const allTables = [...newTableInstances, ...reusedInstances];
     const mmdia = buildMermaidMarkup(allTables);
-    const preview = pre({ class: "mermaid", "mm-src": mmdia });
+    const implemented = !!schema.body.implemented;
 
     const newNames = newTableDefs.map((t) => t.table_name).filter(Boolean);
+
+    const colorMap = Object.fromEntries([
+      ...newNames.map((n) => [n, "#198754"]),
+      ...reusedNames.map((n) => [n, "#6c757d"]),
+    ]);
+    const colorScript = script(domReady(`
+  const colors = ${JSON.stringify(colorMap)};
+  const pre = document.querySelector('.schema-mermaid');
+  if (!pre) return;
+
+  const doRender = () => {
+    mermaid.run({ nodes: [pre], suppressErrors: true, postRenderCallback: () => {
+      for (const g of pre.querySelectorAll('g[id^="entity-"]')) {
+        const name = g.id.replace(/^entity-/, '').replace(/-\\d+$/, '');
+        const color = colors[name];
+        if (color) {
+          const p = g.querySelector('path');
+          if (p) p.setAttribute('fill', color);
+        }
+      }
+      for (const el of pre.querySelectorAll('g.label.name .nodeLabel')) {
+        el.style.color = 'white';
+        el.style.fontWeight = 'bold';
+      }
+    }});
+  };
+
+  // Defer render until tab is visible, then colorize nodes.
+  const pane = pre.closest('.tab-pane');
+  if (pane && !pane.classList.contains('active')) {
+    const link = document.querySelector('[href="#' + pane.id + '"]');
+    if (link) link.addEventListener('shown.bs.tab', doRender, { once: true });
+    else {
+      const o = new MutationObserver(() => {
+        if (pane.classList.contains('active')) { o.disconnect(); doRender(); }
+      });
+      o.observe(pane, { attributes: true, attributeFilter: ['class'] });
+    }
+  } else doRender();
+`));
+
     const legend = div(
       { class: "mt-3 d-flex flex-wrap gap-3 align-items-start" },
       newNames.length
         ? div(
             { class: "d-flex flex-wrap align-items-center gap-1" },
-            span({ class: "me-1 text-muted small" }, "Will be created:"),
+            span(
+              { class: "me-1 text-muted small" },
+              implemented ? "Was created:" : "Will be created:"
+            ),
             ...newNames.map((n) => span({ class: "badge bg-success" }, n))
           )
         : "",
       reusedNames.length
         ? div(
             { class: "d-flex flex-wrap align-items-center gap-1" },
-            span({ class: "me-1 text-muted small" }, "Already exists:"),
+            span(
+              { class: "me-1 text-muted small" },
+              implemented ? "Already existed:" : "Already exists:"
+            ),
             ...reusedNames.map((n) => span({ class: "badge bg-secondary" }, n))
           )
         : ""
@@ -84,9 +131,10 @@ const showSchema = async (req) => {
 
     return div(
       { class: "mt-2" },
-      preview,
-      !schema.body.implemented && legend,
-      !schema.body.implemented &&
+      pre({ class: "schema-mermaid" }, mmdia),
+      colorScript,
+      legend,
+      !implemented &&
         div(
           { class: "mb-4 d-block mt-3" },
           button(

--- a/app-constructor/schema.js
+++ b/app-constructor/schema.js
@@ -69,7 +69,8 @@ const showSchema = async (req) => {
       ...newNames.map((n) => [n, "#198754"]),
       ...reusedNames.map((n) => [n, "#6c757d"]),
     ]);
-    const colorScript = script(domReady(`
+    const colorScript = script(
+      domReady(`
   const colors = ${JSON.stringify(colorMap)};
   const pre = document.querySelector('.schema-mermaid');
   if (!pre) return;
@@ -103,7 +104,8 @@ const showSchema = async (req) => {
       o.observe(pane, { attributes: true, attributeFilter: ['class'] });
     }
   } else doRender();
-`));
+`)
+    );
 
     const legend = div(
       { class: "mt-3 d-flex flex-wrap gap-3 align-items-start" },
@@ -168,15 +170,13 @@ const showSchema = async (req) => {
       ),
       script(
         domReady(`
-(function() {
-  function poll() {
-    view_post(${JSON.stringify(viewname)}, 'schema_status', {}, function(resp) {
-      if (resp && !resp.generating) location.reload();
-      else setTimeout(poll, 3000);
-    });
-  }
-  setTimeout(poll, 3000);
-})();
+const poll = () => {
+  view_post(${JSON.stringify(viewname)}, 'schema_status', {}, (resp) => {
+    if (resp && !resp.generating) location.reload();
+    else setTimeout(poll, 3000);
+  });
+};
+setTimeout(poll, 3000);
 `)
       )
     );

--- a/app-constructor/tasks.js
+++ b/app-constructor/tasks.js
@@ -613,7 +613,7 @@ Important home page rules:
 * Landing/marketing page (public-facing intro): min_role must be "public". It MUST include visible links to /auth/login (Log in) and /auth/signup (Create an account). Set as home for role 100 (public).
 * If there is an admin dashboard page, set it as home for role 1 (admin).
 * If there is a dashboard or main page for regular users or staff, set it as home for role 80 (user) and/or role 40 (staff) as appropriate.
-* The "Set home pages by role" task description must list every role→page mapping explicitly, e.g.: "Set home_page_by_role: public (100) → landing, user (80) → client_dashboard, staff (40) → client_dashboard, admin (1) → admin_dashboard."
+* The "Set home pages by role" task description must list every role→page mapping explicitly using the exact page names planned in this task list, e.g.: "Set home_page_by_role: public (100) → landing, user (80) → client_dashboard, staff (40) → staff_dashboard, admin (1) → app_admin_dashboard." Never use "admin_dashboard" as a page name — it is reserved by the platform.
 
 Important plugin rules:
 * If multiple plugins need to be installed, combine them ALL into a single task named "Install plugins" that lists every required plugin name. Do NOT create a separate task per plugin.

--- a/app-constructor/tasks.js
+++ b/app-constructor/tasks.js
@@ -94,8 +94,17 @@ const makeTaskList = async (req) => {
   });
   const running = !!settings?.body?.running;
   const stopping = !running && rs.some((t) => t.body.status === "Running");
+  const runningTask = rs.find((t) => t.body.status === "Running");
+  const statusText = runningTask
+    ? span(
+        "Running: ",
+        span({ class: "fw-bold" }, runningTask.body.name || "task")
+      )
+    : running
+    ? "Currently running"
+    : "Currently not running";
   const status = div(
-    running ? "Currently running" : "Currently not running",
+    span({ id: "copilot-status-text" }, statusText),
     running
       ? button(
           {
@@ -254,6 +263,8 @@ function copilotInitStopping() {
         setTimeout(poll, 3000);
       } else {
         if (noticeEl) noticeEl.remove();
+        const statusTextEl = document.getElementById('copilot-status-text');
+        if (statusTextEl) statusTextEl.textContent = 'Currently not running';
         if (startBtn) {
           startBtn.disabled = false;
           startBtn.innerHTML = '<i class="fas fa-play me-1"></i>Start running now';
@@ -377,7 +388,9 @@ function copilotStartRunning(btn) {
   btn.disabled = true;
   btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Running...';
   const runNextBtn = document.getElementById('copilot-run-next-btn');
+  const statusTextEl = document.getElementById('copilot-status-text');
   if (runNextBtn) runNextBtn.style.display = 'none';
+  if (statusTextEl) statusTextEl.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Running';
   let stopped = false;
   let stopNotice = null;
   const stopBtn = document.createElement('button');
@@ -387,8 +400,8 @@ function copilotStartRunning(btn) {
     stopped = true;
     stopBtn.disabled = true;
     view_post(${JSON.stringify(viewname)}, 'stop', {});
-    if (document.querySelector('.task-spinner') && !stopNotice) {
-      stopNotice = document.createElement('div');
+    if (!stopNotice) {
+      stopNotice = document.createElement('span');
       stopNotice.className = 'alert alert-warning alert-dismissible d-inline-block ms-2 py-1 px-2 mb-0';
       stopNotice.style.fontSize = '0.875rem';
       stopNotice.innerHTML =
@@ -416,6 +429,8 @@ function copilotStartRunning(btn) {
           } else if (task.status === 'Running') {
             hasRunning = true;
             copilotShowSpinner(task.id);
+            if (statusTextEl) statusTextEl.innerHTML =
+              'Running: <span class="fw-bold">' + (task.name || 'task') + '</span>';
           } else if (task.status !== 'Done') {
             hasPending = true;
           }
@@ -427,6 +442,7 @@ function copilotStartRunning(btn) {
           if (stopNotice) { stopNotice.remove(); stopNotice = null; }
           btn.disabled = false;
           btn.innerHTML = '<i class="fas fa-play me-1"></i>Start running now';
+          if (statusTextEl) statusTextEl.textContent = 'Currently not running';
           if (runNextBtn) runNextBtn.style.display = '';
         }
       });
@@ -440,18 +456,16 @@ function copilotStartRunning(btn) {
         : runningOnLoad
         ? script(
             domReady(`
-(() => {
-  const pollTasks = () => {
-    const spinners = document.querySelectorAll('.task-spinner[data-task-id]');
-    if (!spinners.length) return;
-    const ids = Array.from(spinners).map(el => el.getAttribute('data-task-id'));
-    view_post(${JSON.stringify(viewname)}, 'task_status', {ids}, (resp) => {
-      if (resp && resp.any_done) location.reload();
-      else setTimeout(pollTasks, 3000);
-    });
-  };
-  setTimeout(pollTasks, 3000);
-})();
+const pollTasks = () => {
+  const spinners = document.querySelectorAll('.task-spinner[data-task-id]');
+  if (!spinners.length) return;
+  const ids = Array.from(spinners).map(el => el.getAttribute('data-task-id'));
+  view_post(${JSON.stringify(viewname)}, 'task_status', {ids}, (resp) => {
+    if (resp && resp.any_done) location.reload();
+    else setTimeout(pollTasks, 3000);
+  });
+};
+setTimeout(pollTasks, 3000);
 `)
           )
         : "",
@@ -477,17 +491,13 @@ function copilotStartRunning(btn) {
         ),
         script(
           domReady(`
-(function() {
-  function poll() {
-    view_post(${JSON.stringify(
-      viewname
-    )}, 'planning_status', {}, function(resp) {
-      if (resp && !resp.planning) location.reload();
-      else setTimeout(poll, 3000);
-    });
-  }
-  setTimeout(poll, 3000);
-})();
+const poll = () => {
+  view_post(${JSON.stringify(viewname)}, 'planning_status', {}, (resp) => {
+    if (resp && !resp.planning) location.reload();
+    else setTimeout(poll, 3000);
+  });
+};
+setTimeout(poll, 3000);
 `)
         )
       );
@@ -618,6 +628,10 @@ Important home page rules:
 Important plugin rules:
 * If multiple plugins need to be installed, combine them ALL into a single task named "Install plugins" that lists every required plugin name. Do NOT create a separate task per plugin.
 
+Important dependency rules:
+* Every name in a task's depends_on MUST exactly match the name field of another task in the same plan_tasks call. Never reference a name that is not present in the tasks array — not a concept, not a table name, not a made-up label. If you find yourself writing a depends_on entry whose name does not appear as a task name in the list, either add the missing task or remove the dependency.
+* Before calling plan_tasks, mentally verify: for every task, every name in its depends_on array appears as the name of another task in the array.
+
 Important schema/table rules:
 * The database schema is already fully designed and implemented before task planning begins. ALL tables and fields needed by the application already exist. Do NOT plan any tasks that create tables, add fields, modify fields, or change the schema in any way. If you find yourself writing a task whose output is a table or a field, delete it — that work is already done.
 * Ownership behaviour (auto-setting a FK-to-users field from the logged-in user) is configured in the Edit view, not in the database. Do not create tasks for it at the schema level.
@@ -653,13 +667,27 @@ Before finalising the plan, you may call get_view_config for any existing view y
 
       const planCall = toolCalls.find((tc) => tc.tool_name === "plan_tasks");
       if (planCall) {
-        for (const task of planCall.input.tasks)
+        const plannedNames = new Set(
+          planCall.input.tasks.map((t) => t.name).filter(Boolean)
+        );
+        for (const task of planCall.input.tasks) {
+          const validDeps = (task.depends_on || []).filter((nm) => {
+            if (!plannedNames.has(nm)) {
+              getState().log(
+                2,
+                `AppConstructor: dropping phantom dependency "${nm}" from task "${task.name}" — no such task in plan`
+              );
+              return false;
+            }
+            return true;
+          });
           await MetaData.create({
             type: "CopilotConstructMgr",
             name: "task",
-            body: task,
+            body: { ...task, depends_on: validDeps },
             user_id: userId,
           });
+        }
         break;
       }
 
@@ -784,6 +812,7 @@ const tasks_poll = async (table_id, viewname, config, body, { req, res }) => {
     json: {
       tasks: tasks.map((t) => ({
         id: t.id,
+        name: t.body.name,
         status: t.body.status || "To do",
         run_id: t.body.run_id,
       })),

--- a/app-constructor/tasks.js
+++ b/app-constructor/tasks.js
@@ -293,12 +293,24 @@ function copilotAppendDoneRow(taskId, rowResp) {
 function copilotRunTask(btn, taskId) {
   btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
   btn.disabled = true;
+  const runNextBtn = document.getElementById('copilot-run-next-btn');
+  const startBtn = document.getElementById('copilot-start-btn');
+  if (runNextBtn) runNextBtn.disabled = true;
+  if (startBtn) startBtn.disabled = true;
+  const row = document.querySelector('tr[data-row-id="' + taskId + '"]');
+  const taskName = row ? (row.cells[0]?.textContent?.trim() || '') : '';
+  const statusTextEl = document.getElementById('copilot-status-text');
+  if (statusTextEl) statusTextEl.innerHTML =
+    'Running: <span class="fw-bold">' + (taskName || 'task') + '</span>';
   view_post(${JSON.stringify(viewname)}, 'run_task', {id: taskId}, () => {
     const poll = () => {
       view_post(${JSON.stringify(
         viewname
       )}, 'task_status', {ids: [String(taskId)]}, (resp) => {
         if (resp && resp.any_done) {
+          if (statusTextEl) statusTextEl.textContent = 'Currently not running';
+          if (runNextBtn) runNextBtn.disabled = false;
+          if (startBtn) startBtn.disabled = false;
           view_post(${JSON.stringify(
             viewname
           )}, 'task_row_done', {id: taskId}, (rowResp) => {
@@ -456,6 +468,10 @@ function copilotStartRunning(btn) {
         : runningOnLoad
         ? script(
             domReady(`
+const runNextBtn = document.getElementById('copilot-run-next-btn');
+const startBtn = document.getElementById('copilot-start-btn');
+if (runNextBtn) runNextBtn.disabled = true;
+if (startBtn) startBtn.disabled = true;
 const pollTasks = () => {
   const spinners = document.querySelectorAll('.task-spinner[data-task-id]');
   if (!spinners.length) return;
@@ -604,23 +620,27 @@ Important trigger planning rules:
 Important view planning rules:
 * Each task must create exactly one view. Never put two or more views in the same task. Edit, Show, and List for the same table are always three separate tasks with three separate names, descriptions, and dependencies.
 * Do NOT plan separate tasks for "create" and "edit" on the same table. In Saltcorn, a single Edit view handles both (no id = create, id present = edit). One task, one Edit view, description says "create and edit".
-* Edit, Show, and List views for a table form a natural group and should normally each be planned as their own task. A List without a Show leaves users with no way to inspect details; omit or adjust only when the requirements explicitly say the data is read-only or not editable. When all three are planned, the ordering of tasks must be: Edit and Show first (in either order, they are independent of each other), then List last, because the List depends on both.
-* A List view task must depend on the Edit view task and the Show view task for the same table (if both exist), since its rows link to them. Set depends_on accordingly.
+* Edit, Show, and List views for a table always go together as three separate tasks. Whenever you plan a List view AND a Show view for the same table, you MUST also plan an Edit view for that table — a List without an Edit leaves users unable to create or modify records. Only omit the Edit view when the requirements explicitly say the data is read-only.
+* The three tasks must be ordered: Edit and Show first (independent of each other, in any order), List last. The List task MUST list both the Edit task and the Show task in its depends_on — without exception. If you plan a List that depends on neither, that is a bug in the plan.
+* Before finalising the plan, for every List view task, verify that its depends_on includes the corresponding Edit task and the corresponding Show task (if they exist). If either is missing, add it.
 * When a List view links to a Show view or Edit view, the task description must say: "Add a viewlink column to [view_name] for the current row" — not just "link each row". This wording makes it unambiguous that a viewlink column must be added to the list for each target view.
 * In general, if a view embeds or links to another view, the linked view's task must be listed as a dependency.
 * When a table has foreign key fields referencing the users table, the task description must explicitly state for each one whether it is an ownership field (automatically set from the logged-in user, omit from the form) or a selector field (the user picks a value, include a selector in the form). Example: "user_id records the owner and is set automatically; shared_with_user_id must have a user selector."
 * For FK fields that represent a parent context (e.g. trip_id on packing_items), always include the field as a normal selector in the Edit view form. Do NOT say to omit it. Saltcorn automatically pre-fills the selector from the URL query parameter when the view is opened from a parent context, and the user can select it manually when the view is used standalone.
 * For every task that creates a view, include the exact view name in the task description. View names must be lowercase, snake_case, unique across all tasks in the plan, and descriptive enough to identify the table and purpose — for example 'packing_items_edit' rather than just 'edit'.
-
 Important user account rules:
 * The platform (Saltcorn) provides a built-in user account system with login, registration, and session management. Do NOT plan any tasks for user registration, login pages, password management, authentication flows, or email verification — these are already handled by the platform. Users register at /auth/signup and log in at /auth/login.
 * User identity is always available as the logged-in user. Ownership fields (FK to users) are set automatically from the session; no custom logic is needed.
 * If a requirement mentions "user accounts", "secure login", "saving data per user", "user-specific data", or "sharing between users", treat it as already satisfied by the platform's built-in user system. Do not generate any task in response to such a requirement.
 
+Important role rules:
+* Every view and page task description MUST state the min_role explicitly, e.g. "Set min_role to admin (1)." or "Set min_role to user (80).". Never omit it.
+* Role values: admin=1, staff=40, user=80, public=100. Use the value that matches who will use the view or page — admin for management, staff for staff-only, user for logged-in users (clients, members, etc.), public only when the view or page must be accessible without login.
+
 Important home page rules:
 * Every role should land on the right page after visiting /. Plan a single task "Set home pages by role" that depends on all relevant page tasks and configures home_page_by_role for every role in one step.
 * Role IDs: public=100, user=80, staff=40, admin=1.
-* Landing/marketing page (public-facing intro): min_role must be "public". It MUST include visible links to /auth/login (Log in) and /auth/signup (Create an account). Set as home for role 100 (public).
+* Landing/marketing page (public-facing intro): min_role must be 100 (public). It MUST include visible links to /auth/login (Log in) and /auth/signup (Create an account). Set as home for role 100 (public).
 * If there is an admin dashboard page, set it as home for role 1 (admin).
 * If there is a dashboard or main page for regular users or staff, set it as home for role 80 (user) and/or role 40 (staff) as appropriate.
 * The "Set home pages by role" task description must list every role→page mapping explicitly using the exact page names planned in this task list, e.g.: "Set home_page_by_role: public (100) → landing, user (80) → client_dashboard, staff (40) → staff_dashboard, admin (1) → app_admin_dashboard." Never use "admin_dashboard" as a page name — it is reserved by the platform.
@@ -667,10 +687,10 @@ Before finalising the plan, you may call get_view_config for any existing view y
 
       const planCall = toolCalls.find((tc) => tc.tool_name === "plan_tasks");
       if (planCall) {
-        const plannedNames = new Set(
-          planCall.input.tasks.map((t) => t.name).filter(Boolean)
-        );
-        for (const task of planCall.input.tasks) {
+        const tasks = planCall.input.tasks;
+        const plannedNames = new Set(tasks.map((t) => t.name).filter(Boolean));
+
+        for (const task of tasks) {
           const validDeps = (task.depends_on || []).filter((nm) => {
             if (!plannedNames.has(nm)) {
               getState().log(

--- a/app-constructor/tools.js
+++ b/app-constructor/tools.js
@@ -46,12 +46,13 @@ const task_tool = {
           type: "array",
           items: {
             type: "object",
-            required: ["requirement", "priority"],
+            required: ["name", "description", "priority", "depends_on"],
             additionalProperties: false,
             properties: {
               name: {
                 type: "string",
-                description: "A short name for the task",
+                description:
+                  "A short unique name for the task (snake_case). Every other task that depends on this task must use exactly this name in their depends_on array.",
               },
               description: {
                 type: "string",
@@ -65,7 +66,7 @@ const task_tool = {
               depends_on: {
                 type: "array",
                 description:
-                  "The names of the tasks that must be completed before this tasks can be started",
+                  "Names of tasks in THIS plan that must complete before this task starts. Every name listed here MUST exactly match the name of another task in this same plan_tasks call. Never reference a task name that is not present in the tasks array.",
                 items: {
                   type: "string",
                 },
@@ -78,4 +79,4 @@ const task_tool = {
   },
 };
 
-module.exports = { requirements_tool,task_tool };
+module.exports = { requirements_tool, task_tool };


### PR DESCRIPTION
- Fix pagegen.js min_role hardcoded to 100 — now applied to page and HTML file via File.from_contents; add min_role enum to generate_page schema                
- Remove set_entity file-role instruction from executor prompt (was causing planning text to be saved as HTML content)
- Unify min_role rules for pages and views in planner and executor; never default to public unless page is public-facing
- Fix _showif hallucinated JS expressions — replace copy-able sublabel example with instruction defaulting to blank
- Auto-clear running flag when queue exhausts (was showing stale stop button on page reload)                            
- Disable "Start running now" / "Run next task" while a play-button task runs; revert the already_running server/client approach