### PR TITLE
improve prompt guidance for requirements, planning, and task execution

### DIFF
--- a/actions/generate-page.js
+++ b/actions/generate-page.js
@@ -65,7 +65,9 @@ class GeneratePage {
     };
   }
   static async system_prompt() {
-    return `If the user asks to generate a page, a web page or a landing page, use the generate_page to generate a page.`;
+    return `If the user asks to generate a page, a web page or a landing page, use the generate_page to generate a page.
+
+Critical: When generating HTML, your response must be the complete, final HTML document and nothing else. Do not include reasoning, planning notes, explanatory text, TODO comments, markdown code fences, or placeholder content. Everything you write will be stored verbatim and rendered directly to users — there is no review step between your output and the live page.`;
   }
   static async follow_on_generate({ name, page_type }) {
     if (page_type === "Marketing page") {

--- a/actions/generate-page.js
+++ b/actions/generate-page.js
@@ -71,7 +71,9 @@ class GeneratePage {
     if (page_type === "Marketing page") {
       return {
         prompt:
-          "Generate the HTML for the web page using the Bootstrap 5 CSS framework.",
+          "Generate the HTML for the web page using the Bootstrap 5 CSS framework. " +
+          'Include a toast notification area just before the closing </body> tag: ' +
+          '<div id="toasts-area" class="toast-container position-fixed top-0 start-50 p-0" style="z-index:999;" aria-live="polite" aria-atomic="true"></div>',
       };
     }
     const prompt = `Now generate the contents of the ${name} page`;

--- a/actions/generate-tables.js
+++ b/actions/generate-tables.js
@@ -156,6 +156,11 @@ class GenerateTables {
                 type: "string",
                 description: "The name of the table",
               },
+              description: {
+                type: "string",
+                description:
+                  "A short human-readable description of what this table stores and its role in the application",
+              },
               fields: {
                 type: "array",
                 items: this.field_item_schema(),
@@ -263,6 +268,28 @@ class GenerateTables {
     The type_and_configuration.data_type for a calculated field should reflect the return type of
     the expression (e.g. Integer, Float, String, Bool).
 
+    ## Table descriptions
+
+    Every table you define MUST include a description — a short sentence explaining what
+    the table stores and its role in the application. This description is shown in
+    subsequent prompts to give the planner context about the schema, so make it
+    informative (e.g. "Stores billable time entries logged by lawyers against a project").
+
+    ## Bulk data import and export
+
+    Do NOT create tables whose purpose is to trigger a bulk import or export (e.g. a
+    table with a File field that a user fills in via an Edit view to start an import).
+    Bulk import and export is a UI concern — there are plugins that provide dedicated
+    viewtemplates operating directly on the target table, which is a much better
+    solution than a workaround table with a file field and an Edit view.
+
+    A tracking table that records the status and outcome of an automated import or
+    export process (e.g. import_jobs) is acceptable, but only if the table is populated
+    automatically by the process — not filled in manually by a user. Such tables must
+    have a description that clearly says they are auto-populated and must not be edited
+    by hand (e.g. "Auto-populated by the import process. Records status and errors for
+    each import run. Not editable by users.").
+
     ## Existing tables
 
     The database already contains the following tables:
@@ -293,7 +320,8 @@ class GenerateTables {
 
   static async execute({ tables }, req) {
     const sctables = this.process_tables(tables);
-    for (const table of sctables) await Table.create(table.name);
+    for (const table of sctables)
+      await Table.create(table.name, { description: table.description || "" });
     for (const table of sctables) {
       for (const field of table.fields) {
         field.table = Table.findOne({ name: table.name });
@@ -424,6 +452,7 @@ class GenerateTables {
         : [];
       return new Table({
         name: table.table_name,
+        description: table.description || "",
         fields: sanitizedFields.map((f) => this.process_field(f, tables)),
       });
     });

--- a/agent-skills/pagegen.js
+++ b/agent-skills/pagegen.js
@@ -107,10 +107,11 @@ class GeneratePageSkill {
         const version_tag = db.connectObj.version_tag;
         const asset = (name) => `/static_assets/${version_tag}/${name}`;
         const str = await generate(
-          `Now generate the contents of the ${
+          `Generate the complete HTML for the ${
             tool_call.input.name
-          } HTML page. If I asked you to embed a view,
- use the <embed-view> self-closing tag to do so, setting the view name in the viewname attribute. For example,
+          } page. Your response must be the raw HTML document only — no explanatory text before or after, no markdown code fences, no reasoning, no placeholder comments. The output is saved and rendered directly to users without any review step, so anything you write outside valid HTML will be visible on the page.
+
+ If I asked you to embed a view, use the <embed-view> self-closing tag to do so, setting the view name in the viewname attribute. For example,
  to embed the view LeadForm inside a div, write: <div><embed-view viewname="LeadForm"></div>
 
  If you need to include the standard bootstrap CSS and javascript files, they are available as:

--- a/app-constructor/prompts.js
+++ b/app-constructor/prompts.js
@@ -1,3 +1,5 @@
+const { getState } = require("@saltcorn/data/db/state");
+
 const saltcorn_description = `This application will be implemented in Saltcorn, a database application development
 environment. 
 
@@ -103,6 +105,28 @@ const existing_entities_list = ({ views, triggers, pages, tableById = {} }) => {
   return sections.join("\n\n");
 };
 
+const installed_plugins_list = (installedNames) => {
+  const state = getState();
+  const lines = [];
+  for (const name of installedNames) {
+    const resolvedName = state.plugin_module_names[name] || name;
+    const mod = state.plugins[resolvedName];
+    if (!mod) continue;
+    const contents = mod.contents;
+    const description = mod.description;
+    if (!contents && !description) continue;
+    let line = `### ${name}`;
+    if (description) line += `\n${description}`;
+    if (contents) line += `\n${contents}`;
+    lines.push(line);
+  }
+  if (!lines.length) return "";
+  return (
+    `The following plugins are already installed and their viewtemplates, field types, and actions are available for use:\n\n` +
+    lines.join("\n\n")
+  );
+};
+
 const available_plugins_list = (storePlugins, installedNames) => {
   const uninstalled = storePlugins.filter((p) => !installedNames.has(p.name));
   if (!uninstalled.length) return "";
@@ -125,5 +149,6 @@ module.exports = {
   saltcorn_description,
   existing_tables_list,
   existing_entities_list,
+  installed_plugins_list,
   available_plugins_list,
 };

--- a/app-constructor/requirements.js
+++ b/app-constructor/requirements.js
@@ -153,13 +153,21 @@ Core features: ${spec.body.core_features}
 Out of scope: ${spec.body.out_of_scope}
 Visual style: ${spec.body.visual_style}
 
+Important rules for generating requirements:
+* Every requirement must be directly traceable to something stated in the description, audience, or core features above. Do not infer, invent, or add features that are not explicitly mentioned — even if they seem like an obvious addition.
+* Do not generate any requirement that falls under the Out of scope section above.
+* Only generate requirements for core functionality. Do not generate requirements for features described as optional, "nice to have", "could support", or "can be added later" — omit them entirely.
+* Do NOT generate a requirement for integration with any external third-party system (e.g. QuickBooks, Xero, Stripe, Slack, external APIs, webhooks) unless the specification explicitly names the system AND describes exactly what must be exchanged. A vague mention like "integration with accounting systems" is not sufficient — skip it.
+* Do not generate requirements that are already handled by the platform (e.g. user registration, login, password management — these are built-in).
+* Priority reflects how central the feature is to the core purpose of the application. Assign 5 to features without which the application cannot function at all, 3-4 to features that are important but not blocking, 1-2 to minor convenience features. Do not assign 5 to everything.
+
 Now use the make_requirements tool to list the requirements for this software application
 `,
       {
         tools: [requirements_tool],
         ...tool_choice("make_requirements"),
         systemPrompt:
-          "You are a project manager. The user wants to build an application, and you must analyse their application description",
+          "You are a project manager extracting requirements from a written specification. Only include what is explicitly stated — do not infer or add plausible extras.",
       }
     );
     const tc = answer.getToolCalls()[0];

--- a/app-constructor/run_task.js
+++ b/app-constructor/run_task.js
@@ -85,6 +85,8 @@ Important: Before creating or updating any view or page that embeds, links to, o
 
 Important: A plain Edit view creates or edits a single record — it is NOT a bulk CSV import tool. Never use an Edit view as a solution for CSV import. List views have no built-in CSV export feature — do not add an export button or column to a List view. CSV import and export functionality must always be placed on a dedicated management or admin page as embedded views, using whatever import/export viewtemplate is available.
 
+Important: Every HTML page (page_type HTML) must include a toast notification area so that alerts and success messages are visible. Place this div just before the closing </body> tag: <div id="toasts-area" class="toast-container position-fixed top-0 start-50 p-0" style="z-index:999;" aria-live="polite" aria-atomic="true"></div>
+
 Your task now is:
 ${md.body.description}`;
   const safeReq = req?.__ ? req : { ...req, __: (s) => s, user: req?.user };

--- a/app-constructor/run_task.js
+++ b/app-constructor/run_task.js
@@ -79,7 +79,11 @@ Important: To set a page as the home page for a role, call set_entity directly w
 
 Important: If the task description mentions adding a viewlink, linking rows to another view, or a button that opens another view from a list — that viewlink column MUST be present in the finished view. Do not skip it. Viewlinks require calling get_relation_paths first to obtain the relation string before generating the layout.
 
-Important: Before creating or updating any view or page that embeds, links to, or opens another view (including viewlinks, action buttons, and ajax_modal calls), call list_entities (entity_type "view") to get all existing view names. Only reference views that appear in that list — never invent a name or assume a view exists. If a view is not in the list, omit the reference entirely. Do the same for pages: call list_entities (entity_type "page") before linking to any page by name.
+Important: Every List view must include a delete action column unless the table is explicitly read-only. Use the built-in "Delete" action type for this column.
+
+Important: Before creating or updating any view or page that embeds, links to, or opens another view (including viewlinks, action buttons, and ajax_modal calls), call list_entities (entity_type "view") to get all existing view names. Only reference views that appear in that list — never invent a name or assume a view exists. If a view is not in the list, omit it or use a simple "Coming soon" placeholder — never write conversational text, explanations, or instructions to the user inside the HTML. Always create the page with whatever views exist. Do the same for pages: call list_entities (entity_type "page") before linking to any page by name.
+
+Important: A plain Edit view creates or edits a single record — it is NOT a bulk CSV import tool. Never use an Edit view as a solution for CSV import. List views have no built-in CSV export feature — do not add an export button or column to a List view. CSV import and export functionality must always be placed on a dedicated management or admin page as embedded views, using whatever import/export viewtemplate is available.
 
 Your task now is:
 ${md.body.description}`;

--- a/app-constructor/run_task.js
+++ b/app-constructor/run_task.js
@@ -87,6 +87,8 @@ Important: A plain Edit view creates or edits a single record — it is NOT a bu
 
 Important: Every HTML page (page_type HTML) must include a toast notification area so that alerts and success messages are visible. Place this div just before the closing </body> tag: <div id="toasts-area" class="toast-container position-fixed top-0 start-50 p-0" style="z-index:999;" aria-live="polite" aria-atomic="true"></div>
 
+Important: Every tool call must contain only the final, complete result — never intermediate reasoning, planning notes, markdown code fences, TODO comments, or placeholder text. Compose the full content in your reasoning first, then pass only the finished result to the tool. A page or view that contains any of these is broken and will be visible to end users exactly as written.
+
 Your task now is:
 ${md.body.description}`;
   const safeReq = req?.__ ? req : { ...req, __: (s) => s, user: req?.user };

--- a/app-constructor/tasks.js
+++ b/app-constructor/tasks.js
@@ -46,6 +46,7 @@ const {
   saltcorn_description,
   existing_tables_list,
   existing_entities_list,
+  installed_plugins_list,
   available_plugins_list,
 } = require("./prompts");
 
@@ -546,14 +547,31 @@ setTimeout(poll, 3000);
       );
     }
     return div(
-      { class: "mt-2" },
+      { class: "mt-2", id: "task-gen-area" },
       p("No tasks found"),
       button(
         {
           class: "btn btn-primary",
-          onclick: `press_store_button(this);view_post("${viewname}", "gen_tasks")`,
+          onclick: `copilotGenTasks()`,
         },
         "Plan tasks"
+      ),
+      script(
+        domReady(`
+window.copilotGenTasks = function() {
+  const area = document.getElementById('task-gen-area');
+  if (area) area.innerHTML = '<p><i class="fas fa-spinner fa-spin me-2"></i>Planning tasks, please wait...</p>';
+  view_post(${JSON.stringify(viewname)}, 'gen_tasks', {}, () => {
+    const poll = () => {
+      view_post(${JSON.stringify(viewname)}, 'planning_status', {}, (resp) => {
+        if (resp && !resp.planning) location.reload();
+        else setTimeout(poll, 3000);
+      });
+    };
+    setTimeout(poll, 3000);
+  });
+};
+`)
       )
     );
   }
@@ -602,8 +620,8 @@ const doGenTasks = async (spec, rs, schema, userId) => {
     try {
       storePlugins = await Plugin.store_plugins_available();
     } catch (_) {}
+    const installedPluginsSection = installed_plugins_list(installedNames);
     const pluginsSection = available_plugins_list(storePlugins, installedNames);
-
     const systemPrompt =
       "You are a project manager. The user wants to build an application, and you must analyse their application description";
 
@@ -633,7 +651,7 @@ The plan should outline the continued development of the application on top of t
 Your plan can add additional tables if needed or adjust the table fields, but normally the tables
 should be designed optimally for this application.
 
-${entitiesSection ? entitiesSection + "\n\n" : ""}${
+${entitiesSection ? entitiesSection + "\n\n" : ""}${installedPluginsSection ? installedPluginsSection + "\n\n" : ""}${
         pluginsSection ? pluginsSection + "\n\n" : ""
       }The plan should focus on building views, triggers (including workflows) and pages.
 
@@ -657,10 +675,12 @@ Important view planning rules:
 * The three tasks must be ordered: Edit and Show first (independent of each other, in any order), List last. The List task MUST list both the Edit task and the Show task in its depends_on — without exception. If you plan a List that depends on neither, that is a bug in the plan.
 * Before finalising the plan, for every List view task, verify that its depends_on includes the corresponding Edit task and the corresponding Show task (if they exist). If either is missing, add it.
 * When a List view links to a Show view or Edit view, the task description must say: "Add a viewlink column to [view_name] for the current row" — not just "link each row". This wording makes it unambiguous that a viewlink column must be added to the list for each target view.
+* Every List view task description must include a delete action column unless the table is explicitly read-only. State it explicitly: "Add a delete action column."
 * In general, if a view embeds or links to another view, the linked view's task must be listed as a dependency.
 * When a table has foreign key fields referencing the users table, the task description must explicitly state for each one whether it is an ownership field (automatically set from the logged-in user, omit from the form) or a selector field (the user picks a value, include a selector in the form). Example: "user_id records the owner and is set automatically; shared_with_user_id must have a user selector."
 * For FK fields that represent a parent context (e.g. trip_id on packing_items), always include the field as a normal selector in the Edit view form. Do NOT say to omit it. Saltcorn automatically pre-fills the selector from the URL query parameter when the view is opened from a parent context, and the user can select it manually when the view is used standalone.
 * For every task that creates a view, include the exact view name in the task description. View names must be lowercase, snake_case, unique across all tasks in the plan, and descriptive enough to identify the table and purpose — for example 'packing_items_edit' rather than just 'edit'.
+* Do NOT plan an Edit view for any table whose description says it is auto-populated or not editable by users (e.g. audit logs, import/export job tracking tables). These tables may have List and Show views for read-only visibility, but never an Edit view.
 Important user account rules:
 * The platform (Saltcorn) provides a built-in user account system with login, registration, and session management. Do NOT plan any tasks for user registration, login pages, password management, authentication flows, or email verification — these are already handled by the platform. Users register at /auth/signup and log in at /auth/login.
 * User identity is always available as the logged-in user. Ownership fields (FK to users) are set automatically from the session; no custom logic is needed.
@@ -682,6 +702,12 @@ Important home page rules:
 * If there is an admin dashboard page, set it as home for role 1 (admin).
 * If there is a dashboard or main page for regular users or staff, set it as home for role 80 (user) and/or role 40 (staff) as appropriate.
 * The "Set home pages by role" task description must list every role→page mapping explicitly using the exact page names planned in this task list, e.g.: "Set home_page_by_role: public (100) → landing, user (80) → client_dashboard, staff (40) → staff_dashboard, admin (1) → app_admin_dashboard." Never use "admin_dashboard" as a page name — it is reserved by the platform.
+
+Important bulk import/export rules:
+* A plain Edit view creates or edits a single record — it is NOT a bulk import tool. Never plan an Edit view as a solution for bulk data import.
+* List views have no built-in export feature — do not plan an export button or column as part of a list view.
+* Bulk import and export functionality (e.g. CSV) must always be placed on a dedicated management or admin page as embedded views, using whatever import/export viewtemplate is available from an installed plugin.
+* Bulk import and bulk export for the same table are always two separate tasks with two separate view names. Never combine them into a single task.
 
 Important plugin rules:
 * If multiple plugins need to be installed, combine them ALL into a single task named "Install plugins" that lists every required plugin name. Do NOT create a separate task per plugin.
@@ -824,7 +850,7 @@ const gen_tasks = async (table_id, viewname, config, body, { req, res }) => {
   doGenTasks(spec, rs, schema, req.user?.id).catch((e) =>
     console.error("gen_tasks error", e)
   );
-  return { json: { reload_page: true } };
+  return { json: { success: true } };
 };
 
 const del_task = async (table_id, viewname, config, body, { req, res }) => {

--- a/app-constructor/tasks.js
+++ b/app-constructor/tasks.js
@@ -174,12 +174,12 @@ const makeTaskList = async (req) => {
                 .map((dep) =>
                   doneNames.has(dep)
                     ? span(
-                        { class: "text-success me-2", style: "white-space:nowrap", title: dep },
+                        { class: "dep-indicator text-success me-2", style: "white-space:nowrap", title: dep },
                         i({ class: "fas fa-check-circle me-1", style: "font-size:0.75em" }),
                         dep
                       )
                     : span(
-                        { class: "text-danger me-2", style: "white-space:nowrap", title: dep },
+                        { class: "dep-indicator text-danger me-2", style: "white-space:nowrap", title: dep },
                         i({ class: "fas fa-circle me-1", style: "font-size:0.75em" }),
                         dep
                       )
@@ -312,6 +312,28 @@ function copilotInitStopping() {
   setTimeout(poll, 1000);
 }
 
+function copilotUpdateDepColors() {
+  const doneHeader = Array.from(document.querySelectorAll('h4.list-group-header'))
+    .find(h => h.textContent.trim() === 'Done');
+  const doneNames = new Set();
+  if (doneHeader) {
+    let sib = doneHeader.closest('tr').nextElementSibling;
+    while (sib) {
+      const firstTd = sib.querySelector('td');
+      if (firstTd) doneNames.add(firstTd.textContent.trim());
+      sib = sib.nextElementSibling;
+    }
+  }
+  for (const el of document.querySelectorAll('.dep-indicator')) {
+    const dep = el.getAttribute('title');
+    const done = doneNames.has(dep);
+    el.className = 'dep-indicator me-2 ' + (done ? 'text-success' : 'text-danger');
+    el.style.whiteSpace = 'nowrap';
+    const icon = el.querySelector('i');
+    if (icon) icon.className = (done ? 'fas fa-check-circle' : 'fas fa-circle') + ' me-1';
+  }
+}
+
 function copilotAppendDoneRow(taskId, rowResp) {
   const row = document.querySelector('tr[data-row-id="' + taskId + '"]');
   if (row) row.remove();
@@ -323,6 +345,7 @@ function copilotAppendDoneRow(taskId, rowResp) {
     tmp.innerHTML = rowResp.html;
     tbody.appendChild(tmp.firstChild);
   }
+  copilotUpdateDepColors();
 }
 
 function copilotRunTask(btn, taskId, force) {

--- a/app-constructor/tasks.js
+++ b/app-constructor/tasks.js
@@ -157,6 +157,9 @@ const makeTaskList = async (req) => {
   if (rs.length) {
     const runningOnLoad =
       !stopping && rs.some((t) => t.body.status === "Running");
+    const doneNames = new Set(
+      rs.filter((t) => t.body.status === "Done").map((t) => t.body.name)
+    );
     return div(
       { class: "mt-2" },
       status,
@@ -166,7 +169,22 @@ const makeTaskList = async (req) => {
           { label: "Description", key: (m) => m.body.description },
           {
             label: "Depends on",
-            key: (m) => (m.body.depends_on || []).join(", "),
+            key: (m) =>
+              (m.body.depends_on || [])
+                .map((dep) =>
+                  doneNames.has(dep)
+                    ? span(
+                        { class: "text-success me-2", style: "white-space:nowrap", title: dep },
+                        i({ class: "fas fa-check-circle me-1", style: "font-size:0.75em" }),
+                        dep
+                      )
+                    : span(
+                        { class: "text-danger me-2", style: "white-space:nowrap", title: dep },
+                        i({ class: "fas fa-circle me-1", style: "font-size:0.75em" }),
+                        dep
+                      )
+                )
+                .join(""),
           },
           { label: "Priority", key: (m) => m.body.priority },
           { label: "Status", key: (m) => m.body.status || "To do" },


### PR DESCRIPTION
- table descriptions generated and passed through to planner
- installed plugins included in planning prompt
- requirements scoped strictly to spec: no inferred features, no out-of-scope, no external integrations
- bulk import/export rules: one view per task, dedicated admin page, no Edit view workarounds
- list views always get a delete column
- plan tasks button no longer triggers a page reload
- red/green icon for dependencies
- generate html-file pages with toast-area