### PR TITLE
Harden generated Show view configurations

### DIFF
--- a/agent-skills/generated-view-preview.js
+++ b/agent-skills/generated-view-preview.js
@@ -1,0 +1,33 @@
+const {
+  genericElement,
+  pre,
+  code,
+  escape,
+} = require("@saltcorn/markup/tags");
+
+const renderGeneratedViewConfiguration = (configuration) =>
+  genericElement(
+    "details",
+    { class: "mb-3" },
+    genericElement(
+      "summary",
+      {
+        class: "small fw-semibold text-secondary",
+        style: { cursor: "pointer", userSelect: "none" },
+      },
+      "Generated view configuration",
+    ),
+    pre(
+      {
+        class: "mt-2 mb-0 p-2 border rounded",
+        style: {
+          maxHeight: "32rem",
+          overflow: "auto",
+          whiteSpace: "pre",
+        },
+      },
+      code(escape(JSON.stringify(configuration, null, 2))),
+    ),
+  );
+
+module.exports = { renderGeneratedViewConfiguration };

--- a/agent-skills/viewgen.js
+++ b/agent-skills/viewgen.js
@@ -8,8 +8,6 @@ const {
 const { getState } = require("@saltcorn/data/db/state");
 const {
   div,
-  pre,
-  code,
   a,
   text,
   escape,
@@ -18,6 +16,9 @@ const {
 } = require("@saltcorn/markup/tags");
 const builderGen = require("../builder-gen");
 const { SHOW_LAYOUT_GUIDANCE } = require("../view-layout-guidance");
+const {
+  renderGeneratedViewConfiguration,
+} = require("./generated-view-preview");
 const {
   RELATION_PATH_DOC,
   GET_RELATION_PATHS_FUNCTION,
@@ -534,7 +535,7 @@ class GenerateViewSkill {
         return {
           stop: true,
           add_response:
-            pre(JSON.stringify(wfctx, null, 2)) +
+            renderGeneratedViewConfiguration(wfctx) +
             div(
               { style: { maxHeight: 800, maxWidth: 500, overflow: "scroll" } },
               runres
@@ -635,7 +636,7 @@ class GenerateViewSkill {
         }
         return {
           stop: true,
-          add_response: pre(JSON.stringify(cfg, null, 2)),
+          add_response: renderGeneratedViewConfiguration(cfg),
           add_user_action: {
             name: "build_copilot_view_update",
             type: "button",

--- a/agent-skills/viewgen.js
+++ b/agent-skills/viewgen.js
@@ -17,6 +17,7 @@ const {
   text_attr,
 } = require("@saltcorn/markup/tags");
 const builderGen = require("../builder-gen");
+const { SHOW_LAYOUT_GUIDANCE } = require("../view-layout-guidance");
 const {
   RELATION_PATH_DOC,
   GET_RELATION_PATHS_FUNCTION,
@@ -142,8 +143,9 @@ class GenerateViewSkill {
       `(1) Call get_view_config to fetch the current configuration.\n` +
       `(2) Only if you are adding view_link columns or embedded view (type "view") segments: call get_relation_paths once with all the source_table/target_view pairs you need. For changes that don't involve linking or embedding views (e.g. adding a field, changing a label), skip this step.\n` +
       `(3) Write out the complete updated configuration JSON in full — every key from the existing config must be present, with only your targeted changes merged in.\n` +
-      `(4) Call apply_view_config with that complete object. NEVER call apply_view_config before step (3) is finished. NEVER call it with only the name or a partial object — the configuration field is mandatory and must be the full merged result from step (3). Calling apply_view_config without a complete configuration is an error.\n\n` +
-      `**Generating a new view that contains view_links or embedded views:**\n` +
+      `(4) Call apply_view_config with that complete object. The configuration field contains the full merged result from step (3).\n\n` +
+      SHOW_LAYOUT_GUIDANCE +
+      `\n\n**Generating a new view that contains view_links or embedded views:**\n` +
       `If the task or prompt mentions a viewlink, a link to another view, or a button that opens another view from a list row, that view_link column is REQUIRED — do not omit it. ` +
       `You MUST call get_relation_paths with all source_table/target_view pairs before constructing the layout. Never skip this step when view_links are needed.\n\n` +
       `**Embedded view segment format (for Show layouts):**\n` +
@@ -582,10 +584,9 @@ class GenerateViewSkill {
       function: {
         name: "apply_view_config",
         description:
-          "Save an updated configuration to an existing view. " +
-          "STRICT PRECONDITION: you must have already called get_view_config AND written out the complete merged configuration JSON before calling this tool. " +
-          "Do NOT call this tool as a placeholder or before the configuration is fully constructed. " +
-          "Calling this tool without a complete configuration object is always wrong and will fail.",
+          "Save the complete updated configuration of an existing view after retrieving it with get_view_config. " +
+          "Pass the existing view name and the full merged configuration, preserving every existing key and changing only what the user requested. " +
+          "For Show views, use blank segments for literal labels, field/Field pairs for direct fields, and join_field/JoinField pairs for related fields.",
         parameters: {
           type: "object",
           required: ["name", "configuration"],
@@ -597,9 +598,8 @@ class GenerateViewSkill {
             configuration: {
               type: "object",
               description:
-                "REQUIRED. The complete updated configuration object — every key from the existing config preserved, with only your changes merged in. " +
-                "You MUST have the full object written out before calling this tool. " +
-                "Passing null, an empty object, or a partial object (e.g. only the name) is always wrong and will return an error.",
+                "The complete updated configuration object returned by get_view_config, with every existing key preserved and only the requested changes merged in. " +
+                "For Show views, keep layout segments and configuration.columns synchronized: field with Field, and join_field with JoinField.",
             },
           },
         },

--- a/app-constructor/fixed-prompts.js
+++ b/app-constructor/fixed-prompts.js
@@ -2,6 +2,8 @@
 // Originals in prompts.js are kept intact; these will replace them in a future refactor.
 // Join with "\n\n" to reproduce block-style sections.
 
+const { SHOW_LAYOUT_GUIDANCE } = require("../view-layout-guidance");
+
 const saltcorn_description = [
   `This application will be implemented in Saltcorn, a database application development
 environment.
@@ -497,11 +499,11 @@ Exception: File-type fields hold a file ID and cannot be given a placeholder val
 declare File fields as \`required: false\` (nullable) unless the file is guaranteed to exist
 at the moment the row is first inserted.`,
 
-  `Important: In Show view layouts, every field must be its own separate segment with
-\`"type": "field"\` (singular). There is NO \`"type": "fields"\` (plural) segment — using it
-crashes with "unknown layout segment" at runtime. Never bundle multiple fields into a single
-segment. Each field appears as an individual element in the layout array, for example:
-\`{"type": "field", "field_name": "invoice_date", "fieldview": "show"}\`.`,
+  SHOW_LAYOUT_GUIDANCE,
+
+  `Important: In Show view layouts, every direct field must be its own separate segment with
+\`"type": "field"\` (singular). There is no \`"type": "fields"\` (plural) segment. Never
+bundle multiple fields into a single segment.`,
 ];
 
 const fieldview_selection_rules = [

--- a/tests/generated-view-preview.test.js
+++ b/tests/generated-view-preview.test.js
@@ -1,0 +1,66 @@
+jest.mock("@saltcorn/markup/tags", () => {
+  const escapeText = (value) =>
+    String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;");
+  const renderAttributes = (attributes = {}) =>
+    Object.entries(attributes)
+      .map(([key, value]) => {
+        if (key === "style") {
+          const style = Object.entries(value)
+            .map(([name, setting]) =>
+              `${name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}:${setting}`,
+            )
+            .join(";");
+          return ` style="${style}"`;
+        }
+        return ` ${key}="${value}"`;
+      })
+      .join("");
+  const tag = (name) => (attributes, ...children) => {
+    if (typeof attributes !== "object") return `<${name}>${attributes}</${name}>`;
+    return `<${name}${renderAttributes(attributes)}>${children.join("")}</${name}>`;
+  };
+  return {
+    genericElement: (name, attributes, ...children) =>
+      `<${name}${renderAttributes(attributes)}>${children.join("")}</${name}>`,
+    pre: tag("pre"),
+    code: tag("code"),
+    escape: escapeText,
+  };
+});
+
+const {
+  renderGeneratedViewConfiguration,
+} = require("../agent-skills/generated-view-preview");
+
+describe("generated view configuration preview", () => {
+  test("renders a collapsed details disclosure by default", () => {
+    const html = renderGeneratedViewConfiguration({ layout: { above: [] } });
+
+    expect(html).toContain("<details");
+    expect(html).toContain("<summary");
+    expect(html).toContain("Generated view configuration");
+    expect(html).not.toMatch(/<details[^>]*\sopen(?:[=\s>])/);
+  });
+
+  test("renders formatted JSON only inside the disclosure", () => {
+    const html = renderGeneratedViewConfiguration({ name: "example" });
+
+    expect(html.indexOf("<summary")).toBeLessThan(html.indexOf("<pre"));
+    expect(html).toContain("&quot;name&quot;: &quot;example&quot;");
+    expect(html).toContain("max-height:32rem");
+    expect(html).toContain("overflow:auto");
+  });
+
+  test("escapes generated values before inserting them into HTML", () => {
+    const html = renderGeneratedViewConfiguration({
+      contents: '<script>alert("x")</script>',
+    });
+
+    expect(html).not.toContain('<script>alert("x")</script>');
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/tests/view-layout-guidance.test.js
+++ b/tests/view-layout-guidance.test.js
@@ -1,0 +1,26 @@
+const { SHOW_LAYOUT_GUIDANCE } = require("../view-layout-guidance");
+const { implementation_rules } = require("../app-constructor/fixed-prompts");
+
+describe("Show view layout guidance", () => {
+  test("uses blank segments for literal labels and rejects text segments", () => {
+    expect(SHOW_LAYOUT_GUIDANCE).toContain(
+      '{"type":"blank","contents":"Category"}',
+    );
+    expect(SHOW_LAYOUT_GUIDANCE).toContain('no "text" segment type');
+    expect(SHOW_LAYOUT_GUIDANCE).toContain('never emit {"type":"text"}');
+  });
+
+  test("documents both sides of direct and related field pairs", () => {
+    expect(SHOW_LAYOUT_GUIDANCE).toContain('"type":"field"');
+    expect(SHOW_LAYOUT_GUIDANCE).toContain('"type":"Field"');
+    expect(SHOW_LAYOUT_GUIDANCE).toContain('"type":"join_field"');
+    expect(SHOW_LAYOUT_GUIDANCE).toContain('"type":"JoinField"');
+    expect(SHOW_LAYOUT_GUIDANCE).toContain(
+      '"join_field":"category_id.description"',
+    );
+  });
+
+  test("is included in App Constructor implementation rules", () => {
+    expect(implementation_rules).toContain(SHOW_LAYOUT_GUIDANCE);
+  });
+});

--- a/view-layout-guidance.js
+++ b/view-layout-guidance.js
@@ -1,0 +1,11 @@
+const SHOW_LAYOUT_GUIDANCE = `**Show view layout schema:**
+When adding or replacing standard segments in a Show view, use only these runtime segment types: blank, field, join_field, aggregation, action, view_link, view, link, image, card, tabs, container, table, breadcrumbs, dropdown_menu, line_break, search_bar, page, pageHeader, or prompt. Objects containing above or besides are structural layout containers and may have no type. Preserve any pre-existing plugin-specific segments unchanged.
+
+Use these exact data-display patterns:
+* Static label or other literal text: {"type":"blank","contents":"Category"}. Omit isFormula or set it to false. There is no "text" segment type; never emit {"type":"text"}.
+* Direct table field: put {"type":"field","field_name":"title","fieldview":"show"} in the layout and a matching {"type":"Field","field_name":"title","fieldview":"show"} entry in configuration.columns.
+* Related field reached through a foreign key: put {"type":"join_field","join_field":"category_id.description"} in the layout and a matching {"type":"JoinField","join_field":"category_id.description"} entry in configuration.columns. Both entries are required, and the join_field path must be identical in both. Use this native pair instead of writing {{category_id.description}} in a blank segment.
+
+Keep every existing configuration.columns entry unless the requested change explicitly removes it, and add any Field or JoinField entries required by newly added layout segments.`;
+
+module.exports = { SHOW_LAYOUT_GUIDANCE };


### PR DESCRIPTION
## Summary

- add shared guidance for valid Show layout segment and column pairs
- tell view-generation agents to use `blank` for literal labels and never emit `type: "text"`
- require existing and plugin-specific configuration to be preserved during updates
- render generated configuration in a native `<details>` disclosure, closed by default
- escape JSON values and constrain expanded previews with scrolling

## Validation

```text
PASS tests/view-layout-guidance.test.js
PASS tests/generated-view-preview.test.js
6 tests passed
```

Closes #53
