### PR TITLE
Bound relation path tool output

### DIFF
--- a/agent-skills/viewgen.js
+++ b/agent-skills/viewgen.js
@@ -649,9 +649,17 @@ class GenerateViewSkill {
     const getRelationPathsTool = {
       type: "function",
       function: GET_RELATION_PATHS_FUNCTION,
-      process: async ({ pairs }) => {
+      process: async ({ pairs, max_depth }) => {
         const schemaData = await build_schema_data();
-        const sections = getRelationPathsForPairs(pairs || [], schemaData);
+        const depth = Math.min(
+          6,
+          Math.max(1, Math.trunc(Number(max_depth) || 2)),
+        );
+        const sections = getRelationPathsForPairs(
+          pairs || [],
+          schemaData,
+          depth,
+        );
         return (
           sections.join("\n\n") +
           `\n\nFor each pair, set the "relation" property to one of the strings listed above.\n` +

--- a/relation-paths.js
+++ b/relation-paths.js
@@ -1,5 +1,7 @@
 const { RelationsFinder, RelationType } = require("@saltcorn/common-code");
 
+const MAX_PATHS_PER_PAIR = 40;
+
 /**
  * Relation path documentation included in LLM system prompts (viewgen, builder-gen).
  *
@@ -145,7 +147,7 @@ function getRelationPaths(
  * @param {{ tables, views }} schemaData
  * @returns {Array<string>}  one formatted result string per pair
  */
-function getRelationPathsForPairs(pairs, schemaData, maxDepth = 6) {
+function getRelationPathsForPairs(pairs, schemaData, maxDepth = 2) {
   if (!schemaData)
     return pairs.map(({ source_table, target_view }) =>
       formatRelationPathResult(source_table, target_view, {
@@ -173,12 +175,14 @@ function getRelationPathsForPairs(pairs, schemaData, maxDepth = 6) {
         error: `Failed to find relations: ${e.message}`,
       });
     }
+    const { selected, omitted } = selectRelationPaths(relations);
     return formatRelationPathResult(source_table, target_view, {
-      paths: relations.map((r) => ({
+      paths: selected.map((r) => ({
         relation_string: r.relationString,
         type: String(r.type),
         label: typeToLabel(r.type),
       })),
+      omitted,
     });
   });
 }
@@ -187,6 +191,42 @@ function getRelationPathsForPairs(pairs, schemaData, maxDepth = 6) {
  * Pick the most useful relation from a list: Own > Parent > Child > first.
  * Used as a fallback in builder-gen when the model doesn't specify a relation.
  */
+function selectRelationPaths(relations, limit = MAX_PATHS_PER_PAIR) {
+  const unique = [
+    ...new Map(relations.map((r) => [r.relationString, r])).values(),
+  ];
+  const depth = (relation) =>
+    relation.relationString.split(".").filter(Boolean).length;
+  const comparePaths = (a, b) => {
+    return (
+      depth(a) - depth(b) ||
+      a.relationString.length - b.relationString.length ||
+      a.relationString.localeCompare(b.relationString)
+    );
+  };
+  const byType = new Map();
+  for (const relation of unique.sort(comparePaths)) {
+    const type = String(relation.type);
+    if (!byType.has(type)) byType.set(type, []);
+    byType.get(type).push(relation);
+  }
+
+  const selected = [];
+  while (selected.length < limit) {
+    let found = false;
+    for (const group of byType.values()) {
+      const relation = group.shift();
+      if (!relation) continue;
+      selected.push(relation);
+      found = true;
+      if (selected.length === limit) break;
+    }
+    if (!found) break;
+  }
+  selected.sort(comparePaths);
+  return { selected, omitted: unique.length - selected.length };
+}
+
 function pickBestRelation(relations) {
   if (!relations.length) return null;
   let own = null,
@@ -215,7 +255,10 @@ function formatRelationPathResult(source_table, target_view, result) {
   const lines = result.paths
     .map((p) => `    "${p.relation_string}" — ${p.label}`)
     .join("\n");
-  return `${source_table} → ${target_view}:\n${lines}`;
+  const omitted = result.omitted
+    ? `\n    … ${result.omitted} additional paths omitted; use one of the shortest paths above when suitable.`
+    : "";
+  return `${source_table} → ${target_view}:\n${lines}${omitted}`;
 }
 
 const GET_RELATION_PATHS_FUNCTION = {
@@ -265,5 +308,6 @@ module.exports = {
   GET_RELATION_PATHS_FUNCTION,
   getRelationPaths,
   getRelationPathsForPairs,
+  selectRelationPaths,
   pickBestRelation,
 };

--- a/tests/relation-paths.test.js
+++ b/tests/relation-paths.test.js
@@ -1,0 +1,90 @@
+let mockRelations = [];
+const mockFinderDepths = [];
+
+jest.mock("@saltcorn/common-code", () => ({
+  RelationType: {
+    OWN: "Own",
+    INDEPENDENT: "Independent",
+    PARENT_SHOW: "ParentShow",
+    ONE_TO_ONE_SHOW: "OneToOneShow",
+    CHILD_LIST: "ChildList",
+  },
+  RelationsFinder: class {
+    constructor(_tables, _views, maxDepth) {
+      mockFinderDepths.push(maxDepth);
+    }
+
+    findRelations() {
+      return mockRelations;
+    }
+  },
+}));
+
+const {
+  getRelationPathsForPairs,
+  selectRelationPaths,
+} = require("../relation-paths");
+
+const relation = (relationString, type = "ChildList") => ({
+  relationString,
+  type,
+});
+
+const schemaData = {
+  tables: [{ name: "articles" }, { name: "photos" }],
+  views: [{ name: "photos_list", table_name: "photos" }],
+};
+
+describe("relation path result bounds", () => {
+  beforeEach(() => {
+    mockRelations = [];
+    mockFinderDepths.length = 0;
+  });
+
+  test("starts relation searches at depth two", () => {
+    getRelationPathsForPairs(
+      [{ source_table: "articles", target_view: "photos_list" }],
+      schemaData,
+    );
+
+    expect(mockFinderDepths).toEqual([2]);
+  });
+
+  test("uses an explicitly requested search depth", () => {
+    getRelationPathsForPairs(
+      [{ source_table: "articles", target_view: "photos_list" }],
+      schemaData,
+      4,
+    );
+
+    expect(mockFinderDepths).toEqual([4]);
+  });
+
+  test("keeps the shortest 40 paths and reports omissions", () => {
+    mockRelations = Array.from({ length: 200 }, (_, ix) =>
+      relation(`.articles.long_${ix}.branch.more.photos$article_id`),
+    );
+    mockRelations.push(relation(".articles.photos$article_id"));
+
+    const [result] = getRelationPathsForPairs(
+      [{ source_table: "articles", target_view: "photos_list" }],
+      schemaData,
+      6,
+    );
+
+    expect((result.match(/ — /g) || []).length).toBe(40);
+    expect(result).toContain('".articles.photos$article_id"');
+    expect(result).toContain("161 additional paths omitted");
+  });
+
+  test("retains candidates from different relation types", () => {
+    const relations = Array.from({ length: 80 }, (_, ix) =>
+      relation(`.articles.child_${ix}.photos$article_id`),
+    );
+    relations.push(relation(".articles.owner_id", "ParentShow"));
+
+    const { selected } = selectRelationPaths(relations, 10);
+
+    expect(selected.some((r) => r.type === "ParentShow")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- honor the tool's requested `max_depth`, bounded to 1–6
- use depth 2 as the conservative default
- deduplicate and cap results at 40 paths per source/view pair
- prioritize shorter paths while round-robin sampling relation types
- report omitted candidates instead of returning the full graph

## Validation

```text
PASS tests/relation-paths.test.js
4 tests passed
```

Closes #54
