### PR TITLE
Forward embedded Agent Chat routes

### DIFF
--- a/agent-route-forwarding.js
+++ b/agent-route-forwarding.js
@@ -1,0 +1,24 @@
+const AGENT_CHAT_ROUTE_NAMES = [
+  "interact",
+  "delprevrun",
+  "debug_info",
+  "skillroute",
+  "execute_user_action",
+  "cancel",
+  "tts",
+  "share_chat",
+  "renameprevrun",
+];
+
+const buildAgentRouteForwarders = (getAgentView) =>
+  Object.fromEntries(
+    AGENT_CHAT_ROUTE_NAMES.map((route) => [
+      route,
+      async (tableId, viewname, configuration, body, reqres) => {
+        const view = getAgentView();
+        return await view.runRoute(route, body, reqres.res, reqres);
+      },
+    ]),
+  );
+
+module.exports = { AGENT_CHAT_ROUTE_NAMES, buildAgentRouteForwarders };

--- a/copilot-as-agent.js
+++ b/copilot-as-agent.js
@@ -29,6 +29,7 @@ const {
   textarea,
 } = require("@saltcorn/markup/tags");
 const { getState } = require("@saltcorn/data/db/state");
+const { buildAgentRouteForwarders } = require("./agent-route-forwarding");
 
 const get_state_fields = () => [];
 
@@ -71,21 +72,7 @@ const run = async (table_id, viewname, cfg, state, reqres) => {
   return await get_agent_view().run(state, reqres);
 };
 
-const interact = async (table_id, viewname, config, body, reqres) => {
-  const view = get_agent_view();
-  return await view.runRoute("interact", body, reqres.res, reqres);
-};
-
-const execute_user_action = async (
-  table_id,
-  viewname,
-  config,
-  body,
-  reqres,
-) => {
-  const view = get_agent_view();
-  return await view.runRoute("execute_user_action", body, reqres.res, reqres);
-};
+const routes = buildAgentRouteForwarders(get_agent_view);
 
 module.exports = {
   name: viewname,
@@ -94,5 +81,5 @@ module.exports = {
   tableless: true,
   singleton: true,
   run,
-  routes: { interact, execute_user_action },
+  routes,
 };

--- a/tests/agent-route-forwarding.test.js
+++ b/tests/agent-route-forwarding.test.js
@@ -1,0 +1,44 @@
+const {
+  AGENT_CHAT_ROUTE_NAMES,
+  buildAgentRouteForwarders,
+} = require("../agent-route-forwarding");
+
+describe("Saltcorn Agent copilot route forwarding", () => {
+  test("exposes every route used by the embedded Agent Chat view", () => {
+    expect(AGENT_CHAT_ROUTE_NAMES).toEqual([
+      "interact",
+      "delprevrun",
+      "debug_info",
+      "skillroute",
+      "execute_user_action",
+      "cancel",
+      "tts",
+      "share_chat",
+      "renameprevrun",
+    ]);
+
+    const routes = buildAgentRouteForwarders(() => ({ runRoute: jest.fn() }));
+    expect(Object.keys(routes)).toEqual(AGENT_CHAT_ROUTE_NAMES);
+    AGENT_CHAT_ROUTE_NAMES.forEach((route) =>
+      expect(typeof routes[route]).toBe("function"),
+    );
+  });
+
+  test.each(AGENT_CHAT_ROUTE_NAMES)(
+    "forwards %s to a fresh embedded Agent Chat view",
+    async (route) => {
+      const result = { route };
+      const runRoute = jest.fn().mockResolvedValue(result);
+      const getAgentView = jest.fn(() => ({ runRoute }));
+      const routes = buildAgentRouteForwarders(getAgentView);
+      const body = { run_id: 32 };
+      const reqres = { req: { user: { id: 1 } }, res: { headersSent: false } };
+
+      await expect(
+        routes[route](null, "Saltcorn Agent copilot", {}, body, reqres),
+      ).resolves.toBe(result);
+      expect(getAgentView).toHaveBeenCalledTimes(1);
+      expect(runRoute).toHaveBeenCalledWith(route, body, reqres.res, reqres);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- replace the two ad hoc Copilot route wrappers with shared Agent Chat forwarding
- expose every route used by the embedded chat UI
- restore delete, rename, debug, cancel, share, TTS, and skill route operations
- instantiate a fresh embedded Agent Chat view for each forwarded request, matching the existing behavior

## Validation

```text
PASS tests/agent-route-forwarding.test.js
10 tests passed
```

Closes #55
